### PR TITLE
Add Criterion, CriterionId, CriterionType to report

### DIFF
--- a/src/services/reports/models/ReportRow.php
+++ b/src/services/reports/models/ReportRow.php
@@ -127,6 +127,21 @@ class ReportRow
     public $CriteriaType;
 
     /**
+     * @var string Название или текст условия показа, заданного рекламодателем
+     */
+    public $Criterion;
+
+    /**
+     * @var string Идентификатор условия показа, заданного рекламодателем
+     */
+    public $CriterionId;
+
+    /**
+     * @var string Тип условия показа, заданного рекламодателем
+     */
+    public $CriterionType;
+
+    /**
      * @var float CTR, в процентах
      */
     public $Ctr;


### PR DESCRIPTION
Добавление полей в отчет. Яндекс в своей доке рекомендует использовать их вместо `Criteria`
(https://yandex.ru/dev/direct/doc/reports/report-format-docpage/)

Поле `CriterionId` размечено как строка, так как на деле туда приходит число длиннее чем int32.