### PR TITLE
add jsonSerialize to ReportOrderBy

### DIFF
--- a/src/services/reports/ReportsService.php
+++ b/src/services/reports/ReportsService.php
@@ -201,7 +201,7 @@ class ReportsService extends BaseService
         $dateStart = 'n/a';
         $dateEnd = 'n/a';
         if ($matches) {
-            [$reportName, $dateStart, $dateEnd] = $matches;
+            [,$reportName, $dateStart, $dateEnd] = $matches;
         }
         $names = explode("\t", trim($secondRow, '"'));
         $report = new Report($reportName, $dateStart, $dateEnd, $names);

--- a/src/services/reports/models/ReportOrderBy.php
+++ b/src/services/reports/models/ReportOrderBy.php
@@ -3,8 +3,9 @@
 namespace directapi\services\reports\models;
 
 use directapi\services\reports\enum\ReportOrderByFieldsEnum;
+use JsonSerializable;
 
-class ReportOrderBy
+class ReportOrderBy implements JsonSerializable
 {
     /**
      * @var ReportOrderByFieldsEnum Имя поля, которое используется для сортировки.
@@ -31,4 +32,14 @@ class ReportOrderBy
         $this->field = $field;
         $this->sortOrder = $sortOrder;
     }
+
+	public function jsonSerialize()
+	{
+		$params = [
+			'Field' => $this->field,
+			'SortOrder' => $this->sortOrder,
+		];
+
+		return $params;
+	}
 }


### PR DESCRIPTION
1. Яндекс при запросе отчетов ожидает в секции OrderBy ключ Field с большой буквы.
2. Некорректно парсилось название отчета и даты.